### PR TITLE
Fix tests

### DIFF
--- a/headers/src/header_components/date_time.rs
+++ b/headers/src/header_components/date_time.rs
@@ -84,7 +84,7 @@ mod test {
     ec_test!{ date_time, {
         DateTime::test_time( 45 )
     } => ascii => [
-        Text "Tue,  6 Aug 2013 04:11:45 +0000"
+        Text "Tue, 06 Aug 2013 04:11:45 +0000"
     ]}
 
 }

--- a/headers/src/header_components/disposition.rs
+++ b/headers/src/header_components/disposition.rs
@@ -265,9 +265,9 @@ mod test {
     } => ascii => [
         Text concat!( "attachment",
             "; filename=random.png",
-            "; creation-date=\"Tue,  6 Aug 2013 07:11:01 +0000\"",
-            "; modification-date=\"Tue,  6 Aug 2013 07:11:02 +0000\"",
-            "; read-date=\"Tue,  6 Aug 2013 07:11:03 +0000\"",
+            "; creation-date=\"Tue, 06 Aug 2013 07:11:01 +0000\"",
+            "; modification-date=\"Tue, 06 Aug 2013 07:11:02 +0000\"",
+            "; read-date=\"Tue, 06 Aug 2013 07:11:03 +0000\"",
             "; size=4096" ),
     ]}
 


### PR DESCRIPTION
The tests fail because the leading zero is missing in the expected
output.

I suspect that the tests should pass, though, so simply adding it with
this patch.

---

Should probably be merged before #18 