### PR TITLE
Replace hand implementation of Deserialize, Serialize with derive()

### DIFF
--- a/headers/src/header_components/disposition.rs
+++ b/headers/src/header_components/disposition.rs
@@ -34,13 +34,17 @@ struct DispositionParameters(FileMeta);
 
 /// Represents what kind of disposition is used (Inline/Attachment)
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DispositionKind {
     /// Display the body "inline".
     ///
     /// This disposition is mainly used to add some additional content
     /// and then refers to it through its cid (e.g. in a html mail).
+    #[cfg_attr(feature = "serde", serde(rename = "inline"))]
     Inline,
+
     /// Display the body as an attachment to of the mail.
+    #[cfg_attr(feature = "serde", serde(rename = "attachment"))]
     Attachment
 }
 
@@ -76,52 +80,6 @@ impl Disposition {
         &mut self.file_meta
     }
 
-}
-
-#[cfg(feature="serde")]
-impl Serialize for DispositionKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        match self {
-            &DispositionKind::Inline =>
-                serializer.serialize_str("inline"),
-            &DispositionKind::Attachment =>
-                serializer.serialize_str("attachment")
-        }
-    }
-}
-
-#[cfg(feature="serde")]
-impl<'de> Deserialize<'de> for DispositionKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
-    {
-        struct Visitor;
-        impl<'de> ::serde::de::Visitor<'de> for Visitor {
-            type Value = DispositionKind;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("\"inline\" or \"attachment\"")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-                where E: ::serde::de::Error,
-            {
-                if value.eq_ignore_ascii_case("inline") {
-                    Ok(DispositionKind::Inline)
-                } else if value.eq_ignore_ascii_case("attachment") {
-                    Ok(DispositionKind::Attachment)
-                } else {
-                    Err(E::custom(format!(
-                        "unknown disposition: {:?}", value
-                    )))
-                }
-            }
-        }
-
-        deserializer.deserialize_str(Visitor)
-    }
 }
 
 /// This try from is for usability only, it is


### PR DESCRIPTION
I'm not sure why this was not done before... The error message might differ, but I _guess_ the change leads to equal behaviour in the non-error case, right?

Not sure whether this is tested probably, so I'm simply proposing this ... lets see what's happening :smile: 